### PR TITLE
Added @objc annotations to make TagCellLayout classes available in Objective-C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#TagCellLayout
+#TagCellLayout (Swift-3.0)
 
 [![Build Status](https://travis-ci.org/riteshhgupta/TagCellLayout.svg)](https://travis-ci.org/riteshhgupta/TagCellLayout)
 [![Badge w/ Version](https://cocoapod-badges.herokuapp.com/v/TagCellLayout/badge.png)](https://cocoapods.org/pods/TagCellLayout)
@@ -11,27 +11,6 @@ Its an ui-collection-view LAYOUT class that takes care of all the logic behind m
 
 ##Installation
 To integrate TagCellLayout into your Xcode project using CocoaPods, specify it in your Podfile:
-`If you are using Swift-2.2`
-
-```
-source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
-use_frameworks!
-
-pod 'TagCellLayout', '~> 0.3'
-```
-
-`If you are using Swift-2.3`
-
-```
-source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '8.0'
-use_frameworks!
-
-pod 'TagCellLayout', :git => 'https://github.com/riteshhgupta/TagCellLayout.git', :branch => 'swift2.3'
-```
-
-`If you are using Swift-3.0`
 
 ```
 source 'https://github.com/CocoaPods/Specs.git'

--- a/Source/TagCellLayout.swift
+++ b/Source/TagCellLayout.swift
@@ -5,24 +5,25 @@
 //  Created by Ritesh-Gupta on 20/11/15.
 //  Copyright © 2015 Ritesh. All rights reserved.
 //
+//	Swift 3.0
 
 import Foundation
 import UIKit
 
 public protocol TagCellLayoutDelegate: NSObjectProtocol {
-	func tagCellLayoutTagWidth(layout: TagCellLayout, atIndex index:Int) -> CGFloat
-	func tagCellLayoutTagFixHeight(layout: TagCellLayout) -> CGFloat
+	func tagCellLayoutTagWidth(_ layout: TagCellLayout, atIndex index:Int) -> CGFloat
+	func tagCellLayoutTagFixHeight(_ layout: TagCellLayout) -> CGFloat
 }
 
 public enum TagAlignmentType: Int {
-	case Left
-	case Center
-	case Right
+	case left
+	case center
+	case right
 	
 	var distributionFactor: CGFloat {
 		var factor: CGFloat
 		switch self {
-		case .Center:
+		case .center:
 			factor = 2
 		default:
 			factor = 1
@@ -31,7 +32,7 @@ public enum TagAlignmentType: Int {
 	}
 }
 
-public class TagCellLayout: UICollectionViewLayout {
+open class TagCellLayout: UICollectionViewLayout {
 	
 	struct TagCellLayoutInfo {
 		var layoutAttribute: UICollectionViewLayoutAttributes
@@ -44,7 +45,7 @@ public class TagCellLayout: UICollectionViewLayout {
 	}
 	
 	var layoutInfoList = Array<TagCellLayoutInfo>()
-	var tagAlignmentType = TagAlignmentType.Left
+	var tagAlignmentType = TagAlignmentType.left
 	var numberOfTagsInCurrentRow = 0
 	var currentTagIndex: Int = 0
 	var lineNumber = 1
@@ -56,7 +57,7 @@ public class TagCellLayout: UICollectionViewLayout {
 			position.x += info.bounds.width
 			return position
 		}
-		return CGPointZero
+		return CGPoint.zero
 	}
 	
 	var currentTagLayoutInfo: TagCellLayoutInfo? {
@@ -68,7 +69,7 @@ public class TagCellLayout: UICollectionViewLayout {
 	}
 	
 	var tagsCount: Int {
-		return collectionView?.numberOfItemsInSection(0) ?? 0
+		return collectionView?.numberOfItems(inSection: 0) ?? 0
 	}
 	
 	var collectionViewWidth: CGFloat {
@@ -81,7 +82,7 @@ public class TagCellLayout: UICollectionViewLayout {
 	
 	//MARK: - Init Methods
 	
-	public init(tagAlignmentType: TagAlignmentType = .Left, delegate: TagCellLayoutDelegate?) {
+	public init(tagAlignmentType: TagAlignmentType = .left, delegate: TagCellLayoutDelegate?) {
 		super.init()
 		self.delegate = delegate
 		self.tagAlignmentType = tagAlignmentType
@@ -97,33 +98,33 @@ public class TagCellLayout: UICollectionViewLayout {
 	
 	//MARK: - Override Methods
 	
-	override public func prepareLayout() {
+	override open func prepare() {
 		resetLayoutState()
 		setupTagCellLayout()
 	}
 	
-	override public func layoutAttributesForItemAtIndexPath(indexPath: NSIndexPath) -> UICollectionViewLayoutAttributes? {
-		if layoutInfoList.count > indexPath.row {
-			return layoutInfoList[indexPath.row].layoutAttribute
+	override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+		if layoutInfoList.count > (indexPath as NSIndexPath).row {
+			return layoutInfoList[(indexPath as NSIndexPath).row].layoutAttribute
 		}
 		
 		return nil
 	}
 	
-	override public func layoutAttributesForElementsInRect(rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+	override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
 		if layoutInfoList.count > 0 {
 			let visibleLayoutAttributes = layoutInfoList
 				.map { $0.layoutAttribute }
-				.filter { CGRectIntersectsRect(rect, $0.frame) }
+				.filter { rect.intersects($0.frame) }
 			return visibleLayoutAttributes
 		}
 		return nil
 	}
 	
-	override public func collectionViewContentSize() -> CGSize {
+	override open var collectionViewContentSize : CGSize {
 		if let
 			heightPerLine = delegate?.tagCellLayoutTagFixHeight(self),
-			width = collectionView?.frame.size.width
+			let width = collectionView?.frame.size.width
 		{
 			let height = heightPerLine*CGFloat(lineNumber)
 			return CGSize(width: width, height: height)
@@ -131,7 +132,7 @@ public class TagCellLayout: UICollectionViewLayout {
 		return CGSize.zero
 	}
 	
-	public class func textWidth(text: String, font: UIFont) -> CGFloat {
+	open class func textWidth(_ text: String, font: UIFont) -> CGFloat {
 		let padding: CGFloat = 4 // this number is independent of font and is required to compensate the inaccuracy of sizeToFit calculation!
 		let label = UILabel()
 		label.text = text
@@ -148,7 +149,7 @@ private extension TagCellLayout {
 	
 	func setupTagCellLayout() {
 		// delegate and collectionview shouldn't be nil
-		if let delegate = delegate where collectionView != nil {
+		if let delegate = delegate , collectionView != nil {
 			// basic layout setup which is independent of TagAlignment type
 			basicLayoutSetup(delegate)
 			
@@ -161,7 +162,7 @@ private extension TagCellLayout {
 		}
 	}
 	
-	func basicLayoutSetup(delegate: TagCellLayoutDelegate) {
+	func basicLayoutSetup(_ delegate: TagCellLayoutDelegate) {
 		// asking the client for a fixed tag height
 		
 		// iterating over every tag and constructing its layout attribute
@@ -187,14 +188,14 @@ private extension TagCellLayout {
 			// calculating tag-size
 			let tagHeight = delegate.tagCellLayoutTagFixHeight(self)
 			let tagWidth = delegate.tagCellLayoutTagWidth(self, atIndex: currentTagIndex)
-			let tagSize = CGSizeMake(tagWidth, tagHeight)
+			let tagSize = CGSize(width: tagWidth, height: tagHeight)
 			
 			let layoutInfo = tagCellLayoutInfo(currentTagIndex, tagSize: tagSize)
 			layoutInfoList.append(layoutInfo)
 		}
 	}
 	
-	func tagCellLayoutInfo(tagIndex: Int, tagSize: CGSize) -> TagCellLayoutInfo {
+	func tagCellLayoutInfo(_ tagIndex: Int, tagSize: CGSize) -> TagCellLayoutInfo {
 		// local data-structure (TagCellLayoutInfo) that has been used in this library to store attribute and white-space info
 		var tagFrame = CGRect(origin: currentTagPosition, size: tagSize)
 		
@@ -208,13 +209,13 @@ private extension TagCellLayout {
 		return info
 	}
 	
-	func shouldMoveTagToNextRow(tagWidth: CGFloat) -> Bool {
+	func shouldMoveTagToNextRow(_ tagWidth: CGFloat) -> Bool {
 		return ((currentTagPosition.x + tagWidth) > collectionViewWidth)
 	}
 	
-	func layoutAttribute(tagIndex: Int, tagFrame: CGRect) -> UICollectionViewLayoutAttributes {
-		let indexPath = NSIndexPath(forItem: tagIndex, inSection: 0)
-		let layoutAttribute = UICollectionViewLayoutAttributes(forCellWithIndexPath: indexPath)
+	func layoutAttribute(_ tagIndex: Int, tagFrame: CGRect) -> UICollectionViewLayoutAttributes {
+		let indexPath = IndexPath(item: tagIndex, section: 0)
+		let layoutAttribute = UICollectionViewLayoutAttributes(forCellWith: indexPath)
 		layoutAttribute.frame = tagFrame
 		return layoutAttribute
 	}
@@ -228,7 +229,7 @@ private extension TagCellLayout {
 		}
 	}
 	
-	func applyWhiteSpace(startingIndex startingIndex: Int) {
+	func applyWhiteSpace(startingIndex: Int) {
 		let lastIndex = startingIndex - numberOfTagsInCurrentRow
 		let whiteSpace = calculateWhiteSpace(startingIndex)
 		
@@ -237,21 +238,21 @@ private extension TagCellLayout {
 		}
 	}
 	
-	func calculateWhiteSpace(tagIndex: Int) -> CGFloat {
+	func calculateWhiteSpace(_ tagIndex: Int) -> CGFloat {
 		let tagFrame = tagFrameForIndex(tagIndex)
 		let whiteSpace = collectionViewWidth - (tagFrame.origin.x + tagFrame.size.width)
 		return whiteSpace
 	}
 	
-	func insertWhiteSpace(tagIndex: Int, whiteSpace: CGFloat) {
+	func insertWhiteSpace(_ tagIndex: Int, whiteSpace: CGFloat) {
 		var info = layoutInfoList[tagIndex]
 		let factor = tagAlignmentType.distributionFactor
 		info.whiteSpace = whiteSpace/factor
 		layoutInfoList[tagIndex] = info
 	}
 	
-	func tagFrameForIndex(tagIndex: Int) -> CGRect {
-		let tagFrame =  tagIndex > -1 ? layoutInfoList[tagIndex].layoutAttribute.frame : CGRectZero
+	func tagFrameForIndex(_ tagIndex: Int) -> CGRect {
+		let tagFrame =  tagIndex > -1 ? layoutInfoList[tagIndex].layoutAttribute.frame : CGRect.zero
 		return tagFrame
 	}
 	
@@ -262,8 +263,8 @@ private extension TagCellLayout {
 	}
 	
 	func handleTagAlignment() {
-		if let collectionView = collectionView where tagAlignmentType != .Left {
-			let tagsCount = collectionView.numberOfItemsInSection(0)
+		if let collectionView = collectionView , tagAlignmentType != .left {
+			let tagsCount = collectionView.numberOfItems(inSection: 0)
 			for tagIndex in 0 ..< tagsCount {
 				var tagFrame = layoutInfoList[tagIndex].layoutAttribute.frame
 				let whiteSpace = layoutInfoList[tagIndex].whiteSpace

--- a/Source/TagCellLayout.swift
+++ b/Source/TagCellLayout.swift
@@ -10,12 +10,12 @@
 import Foundation
 import UIKit
 
-public protocol TagCellLayoutDelegate: NSObjectProtocol {
+@objc public protocol TagCellLayoutDelegate: NSObjectProtocol {
 	func tagCellLayoutTagWidth(_ layout: TagCellLayout, atIndex index:Int) -> CGFloat
 	func tagCellLayoutTagFixHeight(_ layout: TagCellLayout) -> CGFloat
 }
 
-public enum TagAlignmentType: Int {
+@objc public enum TagAlignmentType: Int {
 	case left
 	case center
 	case right
@@ -32,7 +32,7 @@ public enum TagAlignmentType: Int {
 	}
 }
 
-open class TagCellLayout: UICollectionViewLayout {
+@objc open class TagCellLayout: UICollectionViewLayout {
 	
 	struct TagCellLayoutInfo {
 		var layoutAttribute: UICollectionViewLayoutAttributes

--- a/TagCellLayout.xcodeproj/project.pbxproj
+++ b/TagCellLayout.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 				TargetAttributes = {
 					3DF12F111BFF4107001B6902 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -228,6 +230,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -264,6 +267,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -272,13 +276,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Ritesh Gupta (F3A8X8B955)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = TagCellLayout/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Ritesh.TagCellLayout;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "ff255666-24e2-4500-b9ea-19ca6b2df949";
+				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -286,13 +291,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Ritesh Gupta (F3A8X8B955)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				INFOPLIST_FILE = TagCellLayout/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.Ritesh.TagCellLayout;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "ff255666-24e2-4500-b9ea-19ca6b2df949";
+				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/TagCellLayout/AppDelegate.swift
+++ b/TagCellLayout/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
 
-  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     return true
   }
 
-  func applicationWillResignActive(application: UIApplication) {
+  func applicationWillResignActive(_ application: UIApplication) {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
   }
 
-  func applicationDidEnterBackground(application: UIApplication) {
+  func applicationDidEnterBackground(_ application: UIApplication) {
     // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
     // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
   }
 
-  func applicationWillEnterForeground(application: UIApplication) {
+  func applicationWillEnterForeground(_ application: UIApplication) {
     // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
   }
 
-  func applicationDidBecomeActive(application: UIApplication) {
+  func applicationDidBecomeActive(_ application: UIApplication) {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
   }
 
-  func applicationWillTerminate(application: UIApplication) {
+  func applicationWillTerminate(_ application: UIApplication) {
     // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
   }
 

--- a/TagCellLayout/TagCollectionViewCell.swift
+++ b/TagCellLayout/TagCollectionViewCell.swift
@@ -16,7 +16,7 @@ class TagCollectionViewCell: UICollectionViewCell {
   override func awakeFromNib() {
     if let tagView = tagView {
       tagView.layer.cornerRadius = tagView.frame.size.height/2 - 2
-      tagView.layer.borderColor = UIColor.blueColor().CGColor
+      tagView.layer.borderColor = UIColor.blue.cgColor
       tagView.layer.borderWidth = 3.0
     }
   }

--- a/TagCellLayout/ViewController.swift
+++ b/TagCellLayout/ViewController.swift
@@ -17,23 +17,23 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
     // Do any additional setup after loading the view, typically from a nib.
   }
 
-  override func viewDidAppear(animated: Bool) {
+  override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     defaultSetup()
 
     // THIS IS ALL WHAT IS REQUIRED TO SETUP YOUR TAGS
 
-    let tagCellLayout = TagCellLayout(tagAlignmentType: .Center, delegate: self)
+    let tagCellLayout = TagCellLayout(tagAlignmentType: .center, delegate: self)
     collectionView?.collectionViewLayout = tagCellLayout
   }
   
   //MARK: - TagCellLayout Delegate Methods
   
-  func tagCellLayoutTagFixHeight(layout: TagCellLayout) -> CGFloat {
+  func tagCellLayoutTagFixHeight(_ layout: TagCellLayout) -> CGFloat {
     return CGFloat(54.0)
   }
   
-  func tagCellLayoutTagWidth(layout: TagCellLayout, atIndex index: Int) -> CGFloat {
+  func tagCellLayoutTagWidth(_ layout: TagCellLayout, atIndex index: Int) -> CGFloat {
     return CGFloat(index%2 == 0 ? 80:120)
   }
   
@@ -46,22 +46,22 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
 
   func defaultSetup() {
     let nib = UINib(nibName: "TagCollectionViewCell", bundle: nil)
-    collectionView?.registerNib(nib, forCellWithReuseIdentifier: "TagCollectionViewCell")
+    collectionView?.register(nib, forCellWithReuseIdentifier: "TagCollectionViewCell")
   }
   
   //MARK: - UICollectionView Delegate/Datasource Methods
   
-  func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let identifier = "TagCollectionViewCell"
-    let cell = collectionView.dequeueReusableCellWithReuseIdentifier(identifier, forIndexPath: indexPath)
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath)
     return cell
   }
   
-  func numberOfSectionsInCollectionView(collectionView: UICollectionView) -> Int {
+  func numberOfSections(in collectionView: UICollectionView) -> Int {
     return 1
   }
   
-  func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
     return 10
   }
   


### PR DESCRIPTION
Methods are:

TagCellLayoutDelegate
` - (CGFloat)tagCellLayoutTagWidth:(TagCellLayout *)layout atIndex:(NSInteger)index`
` - (CGFloat)tagCellLayoutTagFixHeight:(TagCellLayout *)layout`

TagCellLayout
` - (instancetype)initWithAlignmentType:(TagAlignmentType)alignmentType delegate:(id<TagCellLayoutDelegate>)delegate`
` + (CGFloat)textWidth:(NSString *)text font:(UIFont *)font`

NOTES: Unfortunately, Swift bridging makes the delegate `_Nullable` due to TagCellLayout implementation, which prints to console (NSLog) in case of it being `nil`.
It should be `_Nonnull` (since the library simply throws an error message when the delegate is `nil`), but I haven't looked deeper into it.