### PR TITLE
Updated example and added spacings

### DIFF
--- a/Source/TagCellLayout.swift
+++ b/Source/TagCellLayout.swift
@@ -16,7 +16,6 @@ public class TagCellLayout: UICollectionViewLayout {
 	var layoutInfoList: [LayoutInfo] = []
 	var numberOfTagsInCurrentRow = 0
 	var currentTagIndex: Int = 0
-
 	
 	weak var delegate: TagCellLayoutDelegate?
 	
@@ -72,7 +71,7 @@ private extension TagCellLayout {
 	var currentTagFrame: CGRect {
 		guard let info = currentTagLayoutInfo?.layoutAttribute else { return .zero }
 		var frame = info.frame
-		frame.origin.x += info.bounds.width
+		frame.origin.x += info.bounds.width + (delegate?.tagCellLayoutInteritemHorizontalSpacing(layout: self) ?? 0.0)
 		return frame
 	}
 	
@@ -146,7 +145,8 @@ private extension TagCellLayout {
 		// if next tag goes out of screen then move it to next row
 		if shouldMoveTagToNextRow(tagWidth: tagSize.width) {
 			tagFrame.origin.x = 0.0
-			tagFrame.origin.y += currentTagFrame.height
+			tagFrame.origin.y += currentTagFrame.height +
+                (delegate?.tagCellLayoutInteritemVerticalSpacing(layout: self) ?? 0.0)
 			isFirstElementInARow = true
 		}
 		let attribute = layoutAttribute(tagIndex: tagIndex, tagFrame: tagFrame)

--- a/Source/TagCellLayoutDelegate.swift
+++ b/Source/TagCellLayoutDelegate.swift
@@ -12,4 +12,6 @@ import UIKit
 public protocol TagCellLayoutDelegate: NSObjectProtocol {
 	
 	func tagCellLayoutTagSize(layout: TagCellLayout, atIndex index:Int) -> CGSize
+    func tagCellLayoutInteritemHorizontalSpacing(layout: TagCellLayout) -> CGFloat
+    func tagCellLayoutInteritemVerticalSpacing(layout: TagCellLayout) -> CGFloat
 }

--- a/TagCellLayout/TagCollectionViewCell.swift
+++ b/TagCellLayout/TagCollectionViewCell.swift
@@ -18,8 +18,15 @@ class TagCollectionViewCell: UICollectionViewCell {
       tagView.layer.cornerRadius = tagView.frame.size.height/2 - 2
         tagView.layer.borderColor = UIColor.blue.cgColor
       tagView.layer.borderWidth = 3.0
+        tagView.layer.masksToBounds = true
     }
   }
+
+    override var isSelected: Bool {
+        didSet {
+            tagView?.backgroundColor = isSelected ? .blue : .clear
+        }
+    }
 	
 	func configure(with text: String) {
 		tagView?.text = text

--- a/TagCellLayout/TagCollectionViewCell.xib
+++ b/TagCellLayout/TagCollectionViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,13 +20,14 @@
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tags" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XTE-Bs-m9s">
                         <rect key="frame" x="0.0" y="0.0" width="142" height="58"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
             </view>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="XTE-Bs-m9s" secondAttribute="trailing" id="MeS-8d-ODJ"/>
                 <constraint firstAttribute="bottom" secondItem="XTE-Bs-m9s" secondAttribute="bottom" id="Tag-Ll-ceU"/>

--- a/TagCellLayout/ViewController.swift
+++ b/TagCellLayout/ViewController.swift
@@ -24,6 +24,8 @@ class ViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
+        collectionView?.allowsSelection = true
+        collectionView?.allowsMultipleSelection = true
 		// Do any additional setup after loading the view, typically from a nib.
 	}
 	
@@ -33,7 +35,8 @@ class ViewController: UIViewController {
 		
 		// THIS IS ALL WHAT IS REQUIRED TO SETUP YOUR TAGS
 		
-		let tagCellLayout = TagCellLayout(alignment: .center, delegate: self)
+		let tagCellLayout = TagCellLayout(alignment: .left, delegate: self)
+        tagCellLayout.delegate = self
 		collectionView?.collectionViewLayout = tagCellLayout
 	}
 	
@@ -70,7 +73,14 @@ extension ViewController: UICollectionViewDelegate, UICollectionViewDataSource {
 }
 
 extension ViewController: TagCellLayoutDelegate {
-	
+    func tagCellLayoutInteritemHorizontalSpacing(layout: TagCellLayout) -> CGFloat {
+        return 10.0
+    }
+
+    func tagCellLayoutInteritemVerticalSpacing(layout: TagCellLayout) -> CGFloat {
+        return 10.0
+    }
+
 	func tagCellLayoutTagSize(layout: TagCellLayout, atIndex index: Int) -> CGSize {
 		if index == longTagIndex || index == (longTagIndex + 3) {
 			var s = textSize(text: longString, font: UIFont.systemFont(ofSize: 17.0), collectionView: collectionView!)


### PR DESCRIPTION
Pull request contains:
1. Update an example project: 

- I made a small correct of example cell so there is no white rectangle out of shape
- I enabled a selection in example as the purpose of tags is to be able to select them

2. I added 2 methods to delegate:

`func tagCellLayoutInteritemHorizontalSpacing(layout: TagCellLayout) -> CGFloat`
`func tagCellLayoutInteritemVerticalSpacing(layout: TagCellLayout) -> CGFloat`

I'm not sure that values these methods provide are used in correct places of layout calculating but it seems to work.